### PR TITLE
Auto upload generated changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ from the AOSP working directory.
 
 #### Changelog publication
 Every time a new changelog is generated, it is published in the `gh-pages` branch of the current repo.
+This requires the `gh-pages` branch to exist in the current repo.
 
 The `gh-pages` branch is cloned in a subdirectory of the generator repo, the changelog is copied from the AOSP_DIRECTORY, committed and pushed, using the script
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ If this parameter is passed, when a new tag is found on the remote the creation 
 #### Changelog generation
 To generate a changelog between two tags use
 ```
-./get_gitlog.sh <old tag> <new tag>
+$ ./get_gitlog.sh <old tag> <new tag>
 ```
 from the AOSP working directory.
+
+#### Changelog publication
+Every time a new changelog is generated, it is published in the `gh-pages` branch of the current repo.
+
+The `gh-pages` branch is cloned in a subdirectory of the generator repo, the changelog is copied from the AOSP_DIRECTORY, committed and pushed, using the script
+```
+$ ./upload_to_gh_pages.sh <AOSP working directory>
+```
+The param `AOSP working directory` is **mandatory** and must specify the *absolute* path of the directory in which the whole AOSP code has been cloned.

--- a/check_for_new_build_label.sh
+++ b/check_for_new_build_label.sh
@@ -44,6 +44,7 @@ if [ -s $TAGS_FILE.diff ]; then
 	mail -s "New AOSP Build Tags" $ALERT_ADDRESS < $TAGS_FILE.diff
     if [ -n "$AOSP_DIRECTORY" ]; then
         ../../../generate_last_changelog.sh $AOSP_DIRECTORY
+        ../../../upload_to_gh_pages.sh $AOSP_DIRECTORY
     fi
 else
 	log "No new tags found"

--- a/check_for_new_build_label.sh
+++ b/check_for_new_build_label.sh
@@ -11,6 +11,7 @@ log () {
 ALERT_ADDRESS=$1
 AOSP_DIRECTORY=$2
 
+GENERATOR_BASE_DIR=$(pwd)
 WORK_DIRECTORY=./aosp/checkouts/
 GIT_LOG=../../../aosp/build_gitlog
 TAGS_FILE=../../../aosp/existing_build_tags
@@ -43,8 +44,10 @@ if [ -s $TAGS_FILE.diff ]; then
     cat $TAGS_FILE.diff
 	mail -s "New AOSP Build Tags" $ALERT_ADDRESS < $TAGS_FILE.diff
     if [ -n "$AOSP_DIRECTORY" ]; then
-        ../../../generate_last_changelog.sh $AOSP_DIRECTORY
-        ../../../upload_to_gh_pages.sh $AOSP_DIRECTORY
+        cd $GENERATOR_BASE_DIR
+        ./generate_last_changelog.sh $AOSP_DIRECTORY
+        cd $GENERATOR_BASE_DIR
+        ./upload_to_gh_pages.sh $AOSP_DIRECTORY
     fi
 else
 	log "No new tags found"

--- a/upload_to_gh_pages.sh
+++ b/upload_to_gh_pages.sh
@@ -6,7 +6,7 @@ LAST_CHANGELOG_PATH="$AOSP_DIRECTORY/$LAST_CHANGELOG"
 
 PUBLISH_DIRECTORY=./publish/
 CURRENT_REPO_URL=$(git config --get remote.origin.url)
-PUBLISH_BRANCH="gh-pages-test"
+PUBLISH_BRANCH="gh-pages"
 
 # If not existing yet, create the publish dir and init the repo with the publish branch
 if [ ! -d $PUBLISH_DIRECTORY ]; then

--- a/upload_to_gh_pages.sh
+++ b/upload_to_gh_pages.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+AOSP_DIRECTORY=$1
+LAST_CHANGELOG="$(ls $AOSP_DIRECTORY -1t | head -1)"
+LAST_CHANGELOG_PATH="$AOSP_DIRECTORY/$LAST_CHANGELOG"
+
+PUBLISH_DIRECTORY=./publish/
+CURRENT_REPO_URL=$(git config --get remote.origin.url)
+PUBLISH_BRANCH="gh-pages-test"
+
+# If not existing yet, create the publish dir and init the repo with the publish branch
+if [ ! -d $PUBLISH_DIRECTORY ]; then
+    mkdir -p $PUBLISH_DIRECTORY
+    git clone -b $PUBLISH_BRANCH $CURRENT_REPO_URL $PUBLISH_DIRECTORY
+fi
+
+cd $PUBLISH_DIRECTORY
+git pull
+
+# Copy the last changelog and commit it
+cp $LAST_CHANGELOG_PATH ./
+git add .
+git commit -am "New changelog: ${LAST_CHANGELOG%.*}"
+git push


### PR DESCRIPTION
Every time a new changelog is generated, automatically publish it by commit/push on the `gh-pages` branch of the current repo (not hardcoded to the current one).

The `gh-pages` branch is cloned (just pull after the first time) in a subdirectory of the generator repo, the changelog is copied from the `AOSP_DIRECTORY`, committed and pushed
