### PR TITLE
New changelog: android-6.0.1_r18-to-android-6.0.1_r31

### DIFF
--- a/android-6.0.1_r18-to-android-6.0.1_r31.html
+++ b/android-6.0.1_r18-to-android-6.0.1_r31.html
@@ -1,0 +1,281 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="author" content="Novoda Ltd.">
+<link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" >
+<link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" >
+<link rel="stylesheet" type="text/css" href="./assets/style.css" >
+<script async src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script async src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+
+<link rel="icon" href="./assets/favicon.svg" type="image/svg">
+<link rel="shortcut icon" href="./assets/favicon.ico" type="image/x-icon">
+<link rel="author" href="http://www.novoda.com/" >
+
+<title>android-6.0.1_r18 to android-6.0.1_r31 AOSP changelog</title>
+
+<script>
+function show(sectionId) {
+	if (document.getElementById(sectionId)) {
+		document.getElementById(sectionId+'-show').style.display = 'none';
+		document.getElementById(sectionId+'-hide').style.display = 'inline';
+		document.getElementById(sectionId).style.display = 'block';
+	}
+}
+
+function hide(sectionId) {
+	if (document.getElementById(sectionId)) {
+		document.getElementById(sectionId+'-show').style.display = 'inline';
+		document.getElementById(sectionId+'-hide').style.display = 'none';
+		document.getElementById(sectionId).style.display = 'none';
+	}
+}
+</script>
+</head>
+<body>
+<div class="navbar navbar-default navbar-fixed-top">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="./index.html">AOSP Changelogs</a>         
+    </div>
+    <div class="navbar-collapse collapse">
+      <ul class="nav navbar-nav">
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <a class="navbar-brand" href="http://www.novoda.com"><img class="navbar-logo" src="./assets/logo-blue.svg" /></a>
+      </ul>
+    </div>
+  </div>
+</div>
+<div class="container card">
+<div class="row">
+	<div class="col-md-12">
+		<h1>android-6.0.1_r18 to android-6.0.1_r31 AOSP changelog</h1>
+	</div>
+</div>
+
+<div class="row">
+	<div class="col-md-12">
+<p>This only includes the Android Open Source Project changes and does not include any changes
+in any proprietary components included by Google or any hardware manufacturer. The raw log was 
+generated using a modified version of <a href="https://groups.google.com/d/msg/android-building/0DtsHawjs4k/And8o3Dni_UJ">this script</a> written by <a href="https://plus.google.com/112218872649456413744/posts">JBQ</a> and improved by <a href="https://plus.google.com/+AlSutton/posts">Al Sutton</a>.</p>
+
+<p><strong>Please do not copy this without attribution to this site and JBQ for the original script.</strong></p>
+	</div>
+</div>
+<div class="row">
+	<div class="col-md-12">
+		<div id="changes">		
+<p><h2><a href="#" id="platform_bionic-show" class="showLink" onclick="show('platform_bionic');return false;">+</a><a href="#" id="platform_bionic-hide" class="hideLink" onclick="hide('platform_bionic');return false;">-</a>&nbsp;<a name="platform_bionic" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/bionic">platform/bionic</a></h2>
+<div id="platform_bionic"><a href="https://android.googlesource.com/platform/bionic/+/8a19e09">8a19e09</a> :  Update timezone data to 2016a<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_bootable_recovery-show" class="showLink" onclick="show('platform_bootable_recovery');return false;">+</a><a href="#" id="platform_bootable_recovery-hide" class="hideLink" onclick="hide('platform_bootable_recovery');return false;">-</a>&nbsp;<a name="platform_bootable_recovery" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/bootable/recovery">platform/bootable/recovery</a></h2>
+<div id="platform_bootable_recovery"><a href="https://android.googlesource.com/platform/bootable/recovery/+/da64ac2">da64ac2</a> :  Fix integer overflows in recovery procedure.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_build-show" class="showLink" onclick="show('platform_build');return false;">+</a><a href="#" id="platform_build-hide" class="hideLink" onclick="hide('platform_build');return false;">-</a>&nbsp;<a name="platform_build" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/build">platform/build</a></h2>
+<div id="platform_build"><a href="https://android.googlesource.com/platform/build/+/69e221d">69e221d</a> :  M5C14J<br />
+<a href="https://android.googlesource.com/platform/build/+/4b52b92">4b52b92</a> :  M5C14I<br />
+<a href="https://android.googlesource.com/platform/build/+/b69bd61">b69bd61</a> :  "MXC14I"<br />
+<a href="https://android.googlesource.com/platform/build/+/d92a0fe">d92a0fe</a> :  "MXC14H"<br />
+<a href="https://android.googlesource.com/platform/build/+/0b08859">0b08859</a> :  Updating security string patch to 2016-04-01<br />
+</div></p>
+
+<p><h2><a href="#" id="device_google_dragon-show" class="showLink" onclick="show('device_google_dragon');return false;">+</a><a href="#" id="device_google_dragon-hide" class="hideLink" onclick="hide('device_google_dragon');return false;">-</a>&nbsp;<a name="device_google_dragon" class="nonLink">Project:</a> <a href="https://android.googlesource.com/device/google/dragon">device/google/dragon</a></h2>
+<div id="device_google_dragon"><a href="https://android.googlesource.com/device/google/dragon/+/2b01fea">2b01fea</a> :  dragon: sensor: Set FIFO size properly to pass batching CTS tests.<br />
+</div></p>
+
+<p><h2><a href="#" id="device_google_dragon-kernel-show" class="showLink" onclick="show('device_google_dragon-kernel');return false;">+</a><a href="#" id="device_google_dragon-kernel-hide" class="hideLink" onclick="hide('device_google_dragon-kernel');return false;">-</a>&nbsp;<a name="device_google_dragon-kernel" class="nonLink">Project:</a> <a href="https://android.googlesource.com/device/google/dragon-kernel">device/google/dragon-kernel</a></h2>
+<div id="device_google_dragon-kernel"><a href="https://android.googlesource.com/device/google/dragon-kernel/+/c1272e8">c1272e8</a> :  resolve cherry pick fail by taking 37ed1257 dragon: Update prebuilt kernel to 941dd599fba20bd86a695293209976d47078ae67<br />
+<a href="https://android.googlesource.com/device/google/dragon-kernel/+/1e03aef">1e03aef</a> :  dragon: Update prebuilt kernel to dac6ee4b1a6c15e200377c66e0036744e0b35eaf<br />
+</div></p>
+
+<p><h2><a href="#" id="device_sample-show" class="showLink" onclick="show('device_sample');return false;">+</a><a href="#" id="device_sample-hide" class="hideLink" onclick="hide('device_sample');return false;">-</a>&nbsp;<a name="device_sample" class="nonLink">Project:</a> <a href="https://android.googlesource.com/device/sample">device/sample</a></h2>
+<div id="device_sample"><a href="https://android.googlesource.com/device/sample/+/d52feb0">d52feb0</a> :  Adding APN for ATT AGMS Global (310-380)<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_bouncycastle-show" class="showLink" onclick="show('platform_external_bouncycastle');return false;">+</a><a href="#" id="platform_external_bouncycastle-hide" class="hideLink" onclick="hide('platform_external_bouncycastle');return false;">-</a>&nbsp;<a name="platform_external_bouncycastle" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/bouncycastle">platform/external/bouncycastle</a></h2>
+<div id="platform_external_bouncycastle"><a href="https://android.googlesource.com/platform/external/bouncycastle/+/fc47108">fc47108</a> :  GCMParameters: fix insecure tag size<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_dhcpcd-show" class="showLink" onclick="show('platform_external_dhcpcd');return false;">+</a><a href="#" id="platform_external_dhcpcd-hide" class="hideLink" onclick="hide('platform_external_dhcpcd');return false;">-</a>&nbsp;<a name="platform_external_dhcpcd" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/dhcpcd">platform/external/dhcpcd</a></h2>
+<div id="platform_external_dhcpcd"><a href="https://android.googlesource.com/platform/external/dhcpcd/+/94a7bd8">94a7bd8</a> :  Improve length checks in DHCP Options parsing of dhcpcd.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_freetype-show" class="showLink" onclick="show('platform_external_freetype');return false;">+</a><a href="#" id="platform_external_freetype-hide" class="hideLink" onclick="hide('platform_external_freetype');return false;">-</a>&nbsp;<a name="platform_external_freetype" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/freetype">platform/external/freetype</a></h2>
+<div id="platform_external_freetype"><a href="https://android.googlesource.com/platform/external/freetype/+/c14fcff">c14fcff</a> :  [DO NOT MERGE] Update FreeType to 2.6.2 + update from 2.6.0<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_icu-show" class="showLink" onclick="show('platform_external_icu');return false;">+</a><a href="#" id="platform_external_icu-hide" class="hideLink" onclick="hide('platform_external_icu');return false;">-</a>&nbsp;<a name="platform_external_icu" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/icu">platform/external/icu</a></h2>
+<div id="platform_external_icu"><a href="https://android.googlesource.com/platform/external/icu/+/7408a76">7408a76</a> :  Update timezone data to 2016a<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_libavc-show" class="showLink" onclick="show('platform_external_libavc');return false;">+</a><a href="#" id="platform_external_libavc-hide" class="hideLink" onclick="hide('platform_external_libavc');return false;">-</a>&nbsp;<a name="platform_external_libavc" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/libavc">platform/external/libavc</a></h2>
+<div id="platform_external_libavc"><a href="https://android.googlesource.com/platform/external/libavc/+/93f1180">93f1180</a> :  Ensure ih264d_start_of_pic() is not repeated in ih264d_mark_err_slice_skip()<br />
+<a href="https://android.googlesource.com/platform/external/libavc/+/1a12ed8">1a12ed8</a> :  Decoder: Fix stack underflow in CAVLC 4x4 parse functions<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_libmpeg2-show" class="showLink" onclick="show('platform_external_libmpeg2');return false;">+</a><a href="#" id="platform_external_libmpeg2-hide" class="hideLink" onclick="hide('platform_external_libmpeg2');return false;">-</a>&nbsp;<a name="platform_external_libmpeg2" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/libmpeg2">platform/external/libmpeg2</a></h2>
+<div id="platform_external_libmpeg2"><a href="https://android.googlesource.com/platform/external/libmpeg2/+/e2e9cd6">e2e9cd6</a> :  Fixed stack buffer overflow<br />
+<a href="https://android.googlesource.com/platform/external/libmpeg2/+/1af7ccf">1af7ccf</a> :  Fix for handling streams which resulted in negative num_mbs_left<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_libpng-show" class="showLink" onclick="show('platform_external_libpng');return false;">+</a><a href="#" id="platform_external_libpng-hide" class="hideLink" onclick="hide('platform_external_libpng');return false;">-</a>&nbsp;<a name="platform_external_libpng" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/libpng">platform/external/libpng</a></h2>
+<div id="platform_external_libpng"><a href="https://android.googlesource.com/platform/external/libpng/+/2408987">2408987</a> :  DO NOT MERGE Update libpng to 1.6.20<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_pdfium-show" class="showLink" onclick="show('platform_external_pdfium');return false;">+</a><a href="#" id="platform_external_pdfium-hide" class="hideLink" onclick="hide('platform_external_pdfium');return false;">-</a>&nbsp;<a name="platform_external_pdfium" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/pdfium">platform/external/pdfium</a></h2>
+<div id="platform_external_pdfium"><a href="https://android.googlesource.com/platform/external/pdfium/+/8d2f293">8d2f293</a> :  [DO NOT MERGE] Fix the way FreeType headers are incldued.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_sepolicy-show" class="showLink" onclick="show('platform_external_sepolicy');return false;">+</a><a href="#" id="platform_external_sepolicy-hide" class="hideLink" onclick="hide('platform_external_sepolicy');return false;">-</a>&nbsp;<a name="platform_external_sepolicy" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/sepolicy">platform/external/sepolicy</a></h2>
+<div id="platform_external_sepolicy"><a href="https://android.googlesource.com/platform/external/sepolicy/+/6a175ae">6a175ae</a> :  DO NOT MERGE: Further restrict access to socket ioctl commands<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_skia-show" class="showLink" onclick="show('platform_external_skia');return false;">+</a><a href="#" id="platform_external_skia-hide" class="hideLink" onclick="hide('platform_external_skia');return false;">-</a>&nbsp;<a name="platform_external_skia" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/skia">platform/external/skia</a></h2>
+<div id="platform_external_skia"><a href="https://android.googlesource.com/platform/external/skia/+/224ab54">224ab54</a> :  Update SK_CRASH to default to abort(). DO NOT MERGE<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_external_sonivox-show" class="showLink" onclick="show('platform_external_sonivox');return false;">+</a><a href="#" id="platform_external_sonivox-hide" class="hideLink" onclick="hide('platform_external_sonivox');return false;">-</a>&nbsp;<a name="platform_external_sonivox" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/external/sonivox">platform/external/sonivox</a></h2>
+<div id="platform_external_sonivox"><a href="https://android.googlesource.com/platform/external/sonivox/+/91559d8">91559d8</a> :  Sonivox: add SafetyNet log.<br />
+<a href="https://android.googlesource.com/platform/external/sonivox/+/9b999a2">9b999a2</a> :  Sonivox: sanity check numSamples.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_frameworks_av-show" class="showLink" onclick="show('platform_frameworks_av');return false;">+</a><a href="#" id="platform_frameworks_av-hide" class="hideLink" onclick="hide('platform_frameworks_av');return false;">-</a>&nbsp;<a name="platform_frameworks_av" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/frameworks/av">platform/frameworks/av</a></h2>
+<div id="platform_frameworks_av"><a href="https://android.googlesource.com/platform/frameworks/av/+/1919e50">1919e50</a> :  Fixing safteynet logging bug introduced in ag/862848<br />
+<a href="https://android.googlesource.com/platform/frameworks/av/+/06091da">06091da</a> :  Also fix out of bounds access for normal read<br />
+<a href="https://android.googlesource.com/platform/frameworks/av/+/9c84b39">9c84b39</a> :  Get service by value instead of reference<br />
+<a href="https://android.googlesource.com/platform/frameworks/av/+/e17093b">e17093b</a> :  Fix info leak vulnerability of IDrm<br />
+<a href="https://android.googlesource.com/platform/frameworks/av/+/38568d7">38568d7</a> :  3 uninitialized variables in IOMX.cpp<br />
+<a href="https://android.googlesource.com/platform/frameworks/av/+/aed557c">aed557c</a> :  IOMX.cpp uninitialized pointer in BnOMX::onTransact<br />
+<a href="https://android.googlesource.com/platform/frameworks/av/+/b22bf8d">b22bf8d</a> :  Clear allocation to avoid info leak<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_frameworks_base-show" class="showLink" onclick="show('platform_frameworks_base');return false;">+</a><a href="#" id="platform_frameworks_base-hide" class="hideLink" onclick="hide('platform_frameworks_base');return false;">-</a>&nbsp;<a name="platform_frameworks_base" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/frameworks/base">platform/frameworks/base</a></h2>
+<div id="platform_frameworks_base"><a href="https://android.googlesource.com/platform/frameworks/base/+/da11883">da11883</a> :  DO NOT MERGE ANYWHERE: Hack to get devices booting again.<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/229bdcb">229bdcb</a> :  DO NOT MERGE ANYWHERE: Don't change screen on time on time changes<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/5b23737">5b23737</a> :  DO NOT MERGE ANYWHERE: UsageStats: Use new settings key idle_duration2 for app idle<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/f396a95">f396a95</a> :  DO NOT MERGE ANYWHERE: UsageStats: Fix issue where initializing data for first time would cause crash<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/4bd9856">4bd9856</a> :  DO NOT MERGE Read Bluetooth interop database entries from settings (1/2)<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/5aa5962">5aa5962</a> :  DO NOT MERGE Bluetooth: Restrict gain for Absolute volume case<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/1fb3d87">1fb3d87</a> :  Fix missing observer reply callbacks<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/4925826">4925826</a> :  Exit getAllValidScorers early if not the primary.<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/dc02eef">dc02eef</a> :  DO NOT MERGE: Use GregorianCalendar.add() when searching for next alarm.<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/c1c69c4">c1c69c4</a> :  DO NOT MERGE Check apps idle states on time changes<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/5fe6890">5fe6890</a> :  DO NOT MERGE Fix for syncs being dropped when appIdle is on<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/ac63d05">ac63d05</a> :  DO NOT MERGE ANYWHERE: UsageStatsService: Fix app idle issue at rollover time<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/9fb54ae">9fb54ae</a> :  Redact Account info from getCurrentSyncs<br />
+<a href="https://android.googlesource.com/platform/frameworks/base/+/7d7e568">7d7e568</a> :  NPE fix for SyncStorageEngine read authority am: a962d9eba7 am: 339c4f2b05 am: 58048c1f17<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_frameworks_minikin-show" class="showLink" onclick="show('platform_frameworks_minikin');return false;">+</a><a href="#" id="platform_frameworks_minikin-hide" class="hideLink" onclick="hide('platform_frameworks_minikin');return false;">-</a>&nbsp;<a name="platform_frameworks_minikin" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/frameworks/minikin">platform/frameworks/minikin</a></h2>
+<div id="platform_frameworks_minikin"><a href="https://android.googlesource.com/platform/frameworks/minikin/+/405aa9f">405aa9f</a> :  Add error logging on invalid cmap<br />
+<a href="https://android.googlesource.com/platform/frameworks/minikin/+/8c94f6b">8c94f6b</a> :  Reject fonts with invalid ranges in cmap<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_frameworks_native-show" class="showLink" onclick="show('platform_frameworks_native');return false;">+</a><a href="#" id="platform_frameworks_native-hide" class="hideLink" onclick="hide('platform_frameworks_native');return false;">-</a>&nbsp;<a name="platform_frameworks_native" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/frameworks/native">platform/frameworks/native</a></h2>
+<div id="platform_frameworks_native"><a href="https://android.googlesource.com/platform/frameworks/native/+/fcaf6b9">fcaf6b9</a> :  Add AOSP Geomag and Game Rotation, and Gravity<br />
+<a href="https://android.googlesource.com/platform/frameworks/native/+/a120035">a120035</a> :  Manual cherry-pick f5c880cb8e29ec90cf47866f0375799537dcda87 to resolve cherry pick issue Add SN logging<br />
+<a href="https://android.googlesource.com/platform/frameworks/native/+/f748846">f748846</a> :  Sanity check IMemory access versus underlying mmap<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_frameworks_opt_net_wifi-show" class="showLink" onclick="show('platform_frameworks_opt_net_wifi');return false;">+</a><a href="#" id="platform_frameworks_opt_net_wifi-hide" class="hideLink" onclick="hide('platform_frameworks_opt_net_wifi');return false;">-</a>&nbsp;<a name="platform_frameworks_opt_net_wifi" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/frameworks/opt/net/wifi">platform/frameworks/opt/net/wifi</a></h2>
+<div id="platform_frameworks_opt_net_wifi"><a href="https://android.googlesource.com/platform/frameworks/opt/net/wifi/+/80dd99c">80dd99c</a> :  DO NOT MERGE ANYWHERE: Fix issue with WiFi scan reporting<br />
+<a href="https://android.googlesource.com/platform/frameworks/opt/net/wifi/+/643be16">643be16</a> :  DO NOT MERGE Update network priorities before PNO is triggered<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_hardware_libhardware-show" class="showLink" onclick="show('platform_hardware_libhardware');return false;">+</a><a href="#" id="platform_hardware_libhardware-hide" class="hideLink" onclick="hide('platform_hardware_libhardware');return false;">-</a>&nbsp;<a name="platform_hardware_libhardware" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/hardware/libhardware">platform/hardware/libhardware</a></h2>
+<div id="platform_hardware_libhardware"><a href="https://android.googlesource.com/platform/hardware/libhardware/+/66776e1">66776e1</a> :  DO NOT MERGE Add ability to add interop entries dynamically (1/2)<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_libcore-show" class="showLink" onclick="show('platform_libcore');return false;">+</a><a href="#" id="platform_libcore-hide" class="hideLink" onclick="hide('platform_libcore');return false;">-</a>&nbsp;<a name="platform_libcore" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/libcore">platform/libcore</a></h2>
+<div id="platform_libcore"><a href="https://android.googlesource.com/platform/libcore/+/b46c33c">b46c33c</a> :  GCMParameters: check that the default tag size is secure (16 bits)<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_apps_Bluetooth-show" class="showLink" onclick="show('platform_packages_apps_Bluetooth');return false;">+</a><a href="#" id="platform_packages_apps_Bluetooth-hide" class="hideLink" onclick="hide('platform_packages_apps_Bluetooth');return false;">-</a>&nbsp;<a name="platform_packages_apps_Bluetooth" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/apps/Bluetooth">platform/packages/apps/Bluetooth</a></h2>
+<div id="platform_packages_apps_Bluetooth"><a href="https://android.googlesource.com/platform/packages/apps/Bluetooth/+/953dcb0">953dcb0</a> :  DO NOT MERGE Read Bluetooth interop database entries from settings (2/2)<br />
+<a href="https://android.googlesource.com/platform/packages/apps/Bluetooth/+/7d5c0aa">7d5c0aa</a> :  DO NOT MERGE Enhance AVRCP Absolute Volume control implementation<br />
+<a href="https://android.googlesource.com/platform/packages/apps/Bluetooth/+/2c2cbd6">2c2cbd6</a> :  Fix memory leak in Bluetooth AVRCP JNI<br />
+<a href="https://android.googlesource.com/platform/packages/apps/Bluetooth/+/1093c9b">1093c9b</a> :  [DO NOT MERGE ANYWHERE] Null terminate MAP instance information<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_apps_CertInstaller-show" class="showLink" onclick="show('platform_packages_apps_CertInstaller');return false;">+</a><a href="#" id="platform_packages_apps_CertInstaller-hide" class="hideLink" onclick="hide('platform_packages_apps_CertInstaller');return false;">-</a>&nbsp;<a name="platform_packages_apps_CertInstaller" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/apps/CertInstaller">platform/packages/apps/CertInstaller</a></h2>
+<div id="platform_packages_apps_CertInstaller"><a href="https://android.googlesource.com/platform/packages/apps/CertInstaller/+/054d390">054d390</a> :  Trust CA certificates added for the whole OS only<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_apps_Exchange-show" class="showLink" onclick="show('platform_packages_apps_Exchange');return false;">+</a><a href="#" id="platform_packages_apps_Exchange-hide" class="hideLink" onclick="hide('platform_packages_apps_Exchange');return false;">-</a>&nbsp;<a name="platform_packages_apps_Exchange" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/apps/Exchange">platform/packages/apps/Exchange</a></h2>
+<div id="platform_packages_apps_Exchange"><a href="https://android.googlesource.com/platform/packages/apps/Exchange/+/31d5edf">31d5edf</a> :  Patch Exchange Autodiscover Code for Security Issue<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_apps_Settings-show" class="showLink" onclick="show('platform_packages_apps_Settings');return false;">+</a><a href="#" id="platform_packages_apps_Settings-hide" class="hideLink" onclick="hide('platform_packages_apps_Settings');return false;">-</a>&nbsp;<a name="platform_packages_apps_Settings" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/apps/Settings">platform/packages/apps/Settings</a></h2>
+<div id="platform_packages_apps_Settings"><a href="https://android.googlesource.com/platform/packages/apps/Settings/+/d9f1e2d">d9f1e2d</a> :  DO NOT MERGE Modify system settings: incorrect UI state<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_apps_UnifiedEmail-show" class="showLink" onclick="show('platform_packages_apps_UnifiedEmail');return false;">+</a><a href="#" id="platform_packages_apps_UnifiedEmail-hide" class="hideLink" onclick="hide('platform_packages_apps_UnifiedEmail');return false;">-</a>&nbsp;<a name="platform_packages_apps_UnifiedEmail" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/apps/UnifiedEmail">platform/packages/apps/UnifiedEmail</a></h2>
+<div id="platform_packages_apps_UnifiedEmail"><a href="https://android.googlesource.com/platform/packages/apps/UnifiedEmail/+/12065b0">12065b0</a> :  Don't allow file attachment from file:///data.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_providers_ContactsProvider-show" class="showLink" onclick="show('platform_packages_providers_ContactsProvider');return false;">+</a><a href="#" id="platform_packages_providers_ContactsProvider-hide" class="hideLink" onclick="hide('platform_packages_providers_ContactsProvider');return false;">-</a>&nbsp;<a name="platform_packages_providers_ContactsProvider" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/providers/ContactsProvider">platform/packages/providers/ContactsProvider</a></h2>
+<div id="platform_packages_providers_ContactsProvider"><a href="https://android.googlesource.com/platform/packages/providers/ContactsProvider/+/7f027c1">7f027c1</a> :  Update directories when initializing ContactsProvider.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_providers_DownloadProvider-show" class="showLink" onclick="show('platform_packages_providers_DownloadProvider');return false;">+</a><a href="#" id="platform_packages_providers_DownloadProvider-hide" class="hideLink" onclick="hide('platform_packages_providers_DownloadProvider');return false;">-</a>&nbsp;<a name="platform_packages_providers_DownloadProvider" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/providers/DownloadProvider">platform/packages/providers/DownloadProvider</a></h2>
+<div id="platform_packages_providers_DownloadProvider"><a href="https://android.googlesource.com/platform/packages/providers/DownloadProvider/+/3b1f2d6">3b1f2d6</a> :  DO NOT MERGE. Use resolved path when inserting and deleting.<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_services_Telecomm-show" class="showLink" onclick="show('platform_packages_services_Telecomm');return false;">+</a><a href="#" id="platform_packages_services_Telecomm-hide" class="hideLink" onclick="hide('platform_packages_services_Telecomm');return false;">-</a>&nbsp;<a name="platform_packages_services_Telecomm" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/services/Telecomm">platform/packages/services/Telecomm</a></h2>
+<div id="platform_packages_services_Telecomm"><a href="https://android.googlesource.com/platform/packages/services/Telecomm/+/57a1ab6">57a1ab6</a> :  DO NOT MERGE - Restrict ability to add call based on device provision status<br />
+<a href="https://android.googlesource.com/platform/packages/services/Telecomm/+/0997541">0997541</a> :  DO NOT MERGE Check PAH in addNewIncomingCall<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_packages_services_Telephony-show" class="showLink" onclick="show('platform_packages_services_Telephony');return false;">+</a><a href="#" id="platform_packages_services_Telephony-hide" class="hideLink" onclick="hide('platform_packages_services_Telephony');return false;">-</a>&nbsp;<a name="platform_packages_services_Telephony" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/packages/services/Telephony">platform/packages/services/Telephony</a></h2>
+<div id="platform_packages_services_Telephony"><a href="https://android.googlesource.com/platform/packages/services/Telephony/+/c9204eb">c9204eb</a> :  Fixes creation of incorrect SIP PhoneAccountHandle<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_system_bt-show" class="showLink" onclick="show('platform_system_bt');return false;">+</a><a href="#" id="platform_system_bt-hide" class="hideLink" onclick="hide('platform_system_bt');return false;">-</a>&nbsp;<a name="platform_system_bt" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/system/bt">platform/system/bt</a></h2>
+<div id="platform_system_bt"><a href="https://android.googlesource.com/platform/system/bt/+/87cbd02">87cbd02</a> :  DO NOT MERGE Add ability to add interop entries dynamically (2/2)<br />
+<a href="https://android.googlesource.com/platform/system/bt/+/8af8ade">8af8ade</a> :  DO NOT MERGE Remove Porsche car-kit pairing workaround<br />
+</div></p>
+
+<p><h2><a href="#" id="platform_system_core-show" class="showLink" onclick="show('platform_system_core');return false;">+</a><a href="#" id="platform_system_core-hide" class="hideLink" onclick="hide('platform_system_core');return false;">-</a>&nbsp;<a name="platform_system_core" class="nonLink">Project:</a> <a href="https://android.googlesource.com/platform/system/core">platform/system/core</a></h2>
+<div id="platform_system_core"><a href="https://android.googlesource.com/platform/system/core/+/eac695c">eac695c</a> :  Re-derive permissions after package changes.<br />
+<a href="https://android.googlesource.com/platform/system/core/+/bc3c0c1">bc3c0c1</a> :  Don't create tombstone directory.<br />
+</div></p>
+
+
+		</div>
+	</div>
+</div>
+</div>
+
+<div id="footer">
+  <div class="container">
+  	<div class="row">
+	<div class="col-md-6">
+    <p class="text-muted">&copy; Copyright 2015 Novoda Ltd., All Rights Reserved.</p>
+	</div>
+	</div>
+  </div>
+</div>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-59687390-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+</body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
                     <h2>Android 6.0</h2>
 
                     <ul>
+                    <li><a href="android-6.0.1_r18-to-android-6.0.1_r31.html">6.0.1_r31 from 6.0.1_r18</a></li>
                     <li><a href="android-6.0.1_r17-to-android-6.0.1_r30.html">6.0.1_r30 from 6.0.1_r17</a></li>
                     <li><a href="android-6.0.1_r9-to-android-6.0.1_r10.html">6.0.1_r10 from 6.0.1_r9</a></li>
                     <li><a href="android-6.0.1_r8-to-android-6.0.1_r9.html">6.0.1_r9 from 6.0.1_r8</a></li>


### PR DESCRIPTION
This PR uses r18, the previous tag of r31:

```
/aosp.changelog.to/aosp/checkouts/build$ git describe --tags --abbrev=0 android-6.0.1_r31^
android-6.0.1_r18
```
