### PR TITLE
Update parent tag detection

### DIFF
--- a/generate_changelog_from_parent_tag.sh
+++ b/generate_changelog_from_parent_tag.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+TARGET_TAG=$1
+AOSP_DIRECTORY=$2
+
+WORK_DIRECTORY=./aosp/checkouts/build
+cd $WORK_DIRECTORY
+
+# Retrieve the tag right before the target one
+PARENT_TAG=$(git describe --abbrev=0 --tags $TARGET_TAG^)
+
+echo "Generating changelog from $PARENT_TAG to $TARGET_TAG"
+
+# Update the AOSP working directory with a repo sync to the target tag
+cd $AOSP_DIRECTORY
+repo init -u https://android.googlesource.com/platform/manifest -b $TARGET_TAG
+repo sync
+
+./get_gitlog.sh $PARENT_TAG $TARGET_TAG

--- a/generate_last_changelog.sh
+++ b/generate_last_changelog.sh
@@ -2,6 +2,7 @@
 
 AOSP_DIRECTORY=$1
 WORK_DIRECTORY=./aosp/checkouts/build
+GENERATOR_BASE_DIR=$(pwd)
 
 # Prepare the AOSP working directory with the templates and executables used for the changelog generation
 if [ ! -d $AOSP_DIRECTORY ]; then
@@ -18,14 +19,6 @@ LAST_TAGS=$(git for-each-ref refs/tags --sort=-taggerdate --format='%(refname)' 
 TAGS_ARRAY=(`echo $LAST_TAGS | tr "," "\n"`)
 TARGET_TAG=${TAGS_ARRAY[0]}
 
-# Retrieve the tag right before the target one
-PREVIOUS_TAG=$(git describe --abbrev=0 --tags $TARGET_TAG^)
-
-echo "Generating changelog from $PREVIOUS_TAG to $TARGET_TAG"
-
-# Update the AOSP working directory with a repo sync to the target tag
-cd $AOSP_DIRECTORY
-repo init -u https://android.googlesource.com/platform/manifest -b $TARGET_TAG
-repo sync
-
-./get_gitlog.sh $PREVIOUS_TAG $TARGET_TAG
+echo "Target: $TARGET_TAG"
+cd $GENERATOR_BASE_DIR
+./generate_changelog_from_parent_tag.sh $TARGET_TAG $AOSP_DIRECTORY

--- a/generate_last_changelog.sh
+++ b/generate_last_changelog.sh
@@ -19,17 +19,7 @@ TAGS_ARRAY=(`echo $LAST_TAGS | tr "," "\n"`)
 TARGET_TAG=${TAGS_ARRAY[0]}
 
 # Retrieve the tag right before the target one
-LAST_TAGS=$(git for-each-ref refs/tags --sort=refname --format='%(refname)'  | grep -o 'android\-[0-9][\.0-9]*_.*')
-TAGS_ARRAY=(`echo $LAST_TAGS | tr "," "\n"`)
-
-for (( t=1; t<${#TAGS_ARRAY[@]}; t++ ))
-do
-   if [ ${TAGS_ARRAY[$t]} = $TARGET_TAG ]
-   then
-     PREVIOUS_TAG=${TAGS_ARRAY[$t-1]}
-     break
-   fi        
-done
+PREVIOUS_TAG=$(git describe --abbrev=0 --tags $TARGET_TAG^)
 
 echo "Generating changelog from $PREVIOUS_TAG to $TARGET_TAG"
 


### PR DESCRIPTION
### Background

In a changelog generated by our script we define two git tags, _PARENT_ and _TARGET_, in a way that the changelog is `from PARENT to TARGET`.
When a new tag is pushed to AOSP (_TARGET_), we want to find the _PARENT_ one in order to get the differences compared to the new one.
### Problem

We were using just the tag name to find the _PARENT_ tag.
So for example the parent for `android-6.0.1_r46` would have been `android-6.0.1_r45`.
This is actually wrong, as Google uses different tags for different devices.
In our example the right parent for `android-6.0.1_r46` is `android-6.0.1_r43`
### Solution

Instead of using just the tag name, we use the command `git describe --abbrev=0 --tags $TARGET_TAG^` which provides exactly what we need.
### Bonus

Extract the generation of a single changelog to a dedicated script.
This allows us to have a Jenkins job just for that, which can be launched manually with the desired tag as parameter:
![image](https://cloud.githubusercontent.com/assets/3942812/15902580/8002c368-2da0-11e6-8780-536f545727f6.png)
